### PR TITLE
Possibility to makes class partial as C# language.

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,6 +1,6 @@
 # Feature name
 
-* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/proposals/NNNN-name.md)
+* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
 * Author(s): [Swift Developer](https://github.com/swiftdev)
 * Status: **Review**
 * Review manager: TBD

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Swift Programming Language Evolution
 
+**Before you initiate a pull request**, please read the process document. Ideas should be thoroughly discussed on the swift-evolution mailing list first.
+
 This repository tracks the ongoing evolution of Swift. It contains:
 
 * Goals for upcoming Swift releases (this document)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ sampling of potentially good ideas that are not in scope for Swift
   interoperability with C++ is a significant undertaking that is out
   of scope for Swift 3.0.
 
+* **Hygenic Macros**: A first-class macro system is something we may consider
+  in future releases.  We don't want the existence of a macro system to be a
+  workaround that reduces the incentive for making the core language great.
+
+* **Major new Library Functionality**: The Swift Standard Library is focused on
+  providing core "language" functionality as well as common datastructures.  The
+  "corelibs" projects are focused on providing existing Foundation functionality
+  in a portable way.  Major new libraries (e.g. a new Logging subsystem) are
+  best developed as independent projects on GitHub (or elsewhere) and organized
+  with the Swift Package Manager.  Beyond Swift 3 we may consider standardizing
+  popular packages or expanding the scope of the project.  We *will* consider
+  minor extensions to the existing feature set.
+
 ### Accepted proposals for Swift 3.0
 
 * [Better Translation of Objective-C APIs Into Swift](proposals/0005-objective-c-name-translation.md)

--- a/erica-proposal.md
+++ b/erica-proposal.md
@@ -1,0 +1,103 @@
+# Remove C-style for-loops with conditions and incrementers
+
+* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
+* Author(s): [Erica Sadun](https://github.com/erica)
+* Status: **Review**
+* Review manager: TBD
+
+## Introduction
+
+The C-style `for-loop` appears to be a mechanical carry-over from C rather than a
+genuinely Swift-specific construct. It is rarely used and not very Swift-like. 
+
+More Swift-typical construction is already available with `for-in`
+statements and `stride`. Removing for loops would simplify the language and starve the
+most common use-points for `--` and `++`, which are already due to be eliminated from the
+language.
+
+The value of this construct is limited and I believe its removal should be seriously considered.
+
+
+## Advantages of For Loops
+
+Swift design supported a shallow learning curve using familiar constants and control
+structures. The `for-loop` mimics C and limits the effort needed to master this control flow.
+
+## Disadvantages of For Loops
+
+1. Both `for-in` and `stride` provide equivalent behavior using Swift-coherent approaches 
+   without being tied to legacy terminology. 
+1. There is a distinct expressive disadvantage in using `for-loops` compared to `for-in` 
+   in succinctness
+1. `for-loop` implementations do not lend themselves to use with collections and other core Swift types.
+1. The `for-loop` encourages use of unary incrementors and decrementors, which will be
+   soon removed from the language.
+1. The semi-colon delimited declaration offers a steep learning curve from users arriving
+   from non C-like languages
+1. If the `for-loop` did not exist, I doubt it would be considered for inclusion in Swift 3.
+
+## Proposed Approach
+
+I suggest that the for-loop be deprecated in Swift 2.x and removed entirely in Swift 3, with coverage removed from the Swift Programming Language to match the revisions in the current 2.2 update.
+
+## Alternatives considered
+
+Not removing `for-loop` from Swift, losing the opportunity to streamline the language
+and discard an unneeded control flow item.
+
+## Impact on existing code
+
+A search of the Apple Swift codebase suggests this feature is rarely used. Community members of the Swift-Evolution mail list confirm that it does not feature in many pro-level apps and can be worked around for those few times when `for-loop`s do pop up. For example:
+
+```swift
+char *blk_xor(char *dst, const char *src, size_t len)
+{
+ const char *sp = src;
+ for (char *dp = dst; sp - src < len; sp++, dp++)
+   *dp ^= *sp;
+ return dst;
+}
+```
+
+versus
+
+
+```swift
+func blk_xor(dst: UnsafeMutablePointer<CChar>, src:
+UnsafePointer<CChar>, len: Int) -> UnsafeMutablePointer<CChar> {
+   for i in 0..<len {
+       dst[i] ^= src[i]
+   }
+   return dst
+}
+```
+
+A search of github's Swift gists suggests the approach is used primarily by those new to the language with minimal language skills and is abandoned as language mastery is achieved.
+
+For example:
+
+```swift
+for var i = 0 ; i < 10 ; i++ {
+    print(i)
+}
+```
+
+and 
+
+```swift
+var array = [10,20,30,40,50]
+for(var i=0 ; i < array.count ;i++){
+    println("array[i] \(array[i])")
+}
+```
+
+## Community Responses
+* "I am certainly open to considering dropping the C-style for loop.  IMO, it is a rarely used feature of Swift that doesn’t carry its weight.  Many of the reasons to remove them align with the rationale for removing -- and ++. " -- Chris Lattner, clattner@apple.com
+* "My intuition *completely* agrees that Swift no longer needs C-style for loops. We have richer, better-structured looping and functional algorithms. That said, one bit of data I’d like to see is how often C-style for loops are actually used in Swift. It’s something a quick crawl through Swift sources on GitHub could establish. If the feature feels anachronistic and is rarely used, it’s a good candidate for removal." -- Douglas Gregnor, dgregor@apple.com
+* "Every time I’ve used a C-style for loop in Swift it was because I forgot that .indices existed. If it’s removed, a fixme pointing that direction might be useful." -- David Smith, david_smith@apple.com
+* "For what it's worth we don't have a single C style for loop in the Lyft codebase." -- Keith Smiley, keithbsmiley@gmail.com
+* "Just checked; ditto Khan Academy." -- Andy Matsuchak, andy@andymatuschak.org
+* "We’ve developed a number of Swift apps for various clients over the past year and have not needed C style for loops either." -- Eric Chamberlain, eric.chamberlain@arctouch.com
+* "Every time I've tried to use a C-style for loop, I've ended up switching to a while loop because my iteration variable ended up having the wrong type (e.g. having an optional type when the value must be non-optional for the body to execute). The Postmates codebase contains no instances of C-style for loops in Swift." -- Kevin Ballard, kevin@sb.org
+* "I found a couple of cases of them in my codebase, but they were trivially transformed into “proper” Swift-style for loops that look better anyway. If it were a vote, I’d vote for eliminating C-style." -- Sean Heber, sean@fifthace.com
+

--- a/proposals/0001-keywords-as-argument-labels.md
+++ b/proposals/0001-keywords-as-argument-labels.md
@@ -37,7 +37,7 @@ Allow the use of all keywords except `inout`, `var`, and `let` as argument label
 
 * Call expressions, such as the examples above. Here, we have no grammatic ambiguities, because "<keyword> \`:\`" does not appear in any grammar production within a parenthesized expression list. This is, by far, the most important case.
 
-* Function/subscript/initializer declarations: aside from the three exclusions above, there is no ambiguity here because the keyword will always be followed by an identifier, ‘:’, or ‘_'. For example:
+* Function/subscript/initializer declarations: aside from the three exclusions above, there is no ambiguity here because the keyword will always be followed by an identifier, ‘:’, or ‘_’. For example:
 
 ```
 func touchesMatching(phase: NSTouchPhase, in view: NSView?) -> Set<NSTouch>

--- a/proposals/0001-keywords-as-argument-labels.md
+++ b/proposals/0001-keywords-as-argument-labels.md
@@ -70,7 +70,7 @@ does not change the behavior of any well-formed code.
 The primarily alternative here is to do nothing: Swift APIs will
 continue to avoid keywords for argument labels, even when they are the
 most natural word for the label, and imported APIs will either
-continue to use backticks to will need to be renamed. This alternative
+continue to use backticks or will need to be renamed. This alternative
 leaves a large number of imported APIs (nearly 200) requiring either
 some level of renaming of the API or backticks at the call site.
 

--- a/proposals/0002-remove-currying.md
+++ b/proposals/0002-remove-currying.md
@@ -59,7 +59,7 @@ can be transformed to explicitly return a closure instead:
 
   // After:
   func curried(x: Int) -> (String) -> Float {
-    return {(y: String -> Float) in
+    return {(y: String) -> Float in
       return Float(x) + Float(y)!
     }
   }

--- a/proposals/0002-remove-currying.md
+++ b/proposals/0002-remove-currying.md
@@ -1,6 +1,6 @@
 # Removing currying `func` declaration syntax
 
-* Proposal: [SE-0002](https://github.com/apple/swift-evolution/proposals/0002-remove-currying.md)
+* Proposal: [SE-0002](https://github.com/apple/swift-evolution/blob/master/proposals/0002-remove-currying.md)
 * Author(s): [Joe Groff](https://github.com/jckarter)
 * Status: **Accepted**
 

--- a/proposals/0003-remove-var-parameters-patterns.md
+++ b/proposals/0003-remove-var-parameters-patterns.md
@@ -1,6 +1,6 @@
 # Removing `var` from Function Parameters and Pattern Matching
 
-* Proposal: [SE-0003](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-patterns-and-parameters.md)
+* Proposal: [SE-0003](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters-patterns.md)
 * Author(s): [David Farler](https://github.com/bitjammer)
 * Status: **Accepted**
 * Review manager: [Joe Pamer](https://github.com/jopamer)

--- a/proposals/0003-remove-var-parameters-patterns.md
+++ b/proposals/0003-remove-var-parameters-patterns.md
@@ -1,6 +1,6 @@
 # Removing `var` from Function Parameters and Pattern Matching
 
-* Proposal: [SE-0003](https://github.com/apple/swift-evolution/proposals/0003-remove-var-patterns-and-parameters.md)
+* Proposal: [SE-0003](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-patterns-and-parameters.md)
 * Author(s): [David Farler](https://github.com/bitjammer)
 * Status: **Accepted**
 * Review manager: [Joe Pamer](https://github.com/jopamer)

--- a/proposals/0003-remove-var-parameters-patterns.md
+++ b/proposals/0003-remove-var-parameters-patterns.md
@@ -204,7 +204,7 @@ func mkdtemp(var prefix: String?) -> Path {
 only uses immutable values:
 
 ```swift
-func mkdtemp(prefix: String) -> Path {
+func mkdtemp(prefix: String?) -> Path {
   return Path(prefix ?? getenv("TMPDIR") ?? "/tmp", getUniqueSuffix())
 }
 ```

--- a/proposals/0004-remove-pre-post-inc-decrement.md
+++ b/proposals/0004-remove-pre-post-inc-decrement.md
@@ -1,6 +1,6 @@
 # Remove the `++` and `--` operators
 
-* Proposal: [SE-0004](https://github.com/apple/swift-evolution/proposals/0004-remove-pre-post-inc-decrement.md)
+* Proposal: [SE-0004](https://github.com/apple/swift-evolution/blob/master/proposals/0004-remove-pre-post-inc-decrement.md)
 * Author: [Chris Lattner](https://github.com/lattner)
 * Status: **Accepted**
 

--- a/proposals/0005-objective-c-name-translation.md
+++ b/proposals/0005-objective-c-name-translation.md
@@ -75,13 +75,13 @@ renaming of any C or Objective-C entity when it is imported into
 Swift, allowing authors of C or Objective-C APIs more fine-grained
 control over the process.
 
-2. **Prune redundant type names**: The Objective-C Coding Guidelines for Cocoa require that the method describe each argument. When those descriptions restate the type of the corresponding parameter, the name conflicts with the [omit needless words](https://swift.org/documentation/api-design-guidelines#omit-needless-words) guideline for Swift APIs. Therefore, we prune these type names during import.
+2. **Prune redundant type names**: The Objective-C Coding Guidelines for Cocoa require that the method describe each argument. When those descriptions restate the type of the corresponding parameter, the name conflicts with the [omit needless words](https://swift.org/documentation/api-design-guidelines.html#omit-needless-words) guideline for Swift APIs. Therefore, we prune these type names during import.
 
 3. **Add default arguments**: In cases where the Objective-C API strongly hints at the need for a default argument, infer the default argument when importing the API. For example, an option-set parameter can be defaulted to `[]`.
 
-4. **Add first argument labels**: If the first parameter of a method is defaulted, [it should have an argument label](https://swift.org/documentation/api-design-guidelines#first-argument-label). Determine a first argument label for that method.
+4. **Add first argument labels**: If the first parameter of a method is defaulted, [it should have an argument label](https://swift.org/documentation/api-design-guidelines.html#first-argument-label). Determine a first argument label for that method.
 
-5. **Prepend "is" to Boolean properties**: [Boolean properties should read as assertions on the receiver](https://swift.org/documentation/api-design-guidelines#first-argument-label), but the Objective-C Coding Guidelines for Cocoa [prohibit the use of "is" on properties](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingIvarsAndTypes.html#//apple_ref/doc/uid/20001284-BAJGIIJE). Import such properties with "is" prepended.
+5. **Prepend "is" to Boolean properties**: [Boolean properties should read as assertions on the receiver](https://swift.org/documentation/api-design-guidelines.html#first-argument-label), but the Objective-C Coding Guidelines for Cocoa [prohibit the use of "is" on properties](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingIvarsAndTypes.html#//apple_ref/doc/uid/20001284-BAJGIIJE). Import such properties with "is" prepended.
 
 6. **Strip the "NS" prefix from Foundation APIs**: Foundation is a
 fundamental part of the [Swift Core Libraries][core-libraries], and
@@ -180,7 +180,7 @@ The descriptions in this section are described in terms of the incoming Objectiv
 
 Objective-C API names often contain names of parameter and/or result
 types that would be omitted in a Swift API. The following rules are
-designed to identify and remove these words. [[Omit Needless Words](https://swift.org/documentation/api-design-guidelines#omit-needless-words)]
+designed to identify and remove these words. [[Omit Needless Words](https://swift.org/documentation/api-design-guidelines.html#omit-needless-words)]
 
 #### Identifying type names
 
@@ -209,7 +209,7 @@ a suffix of a string called the **type name**, which is defined as follows:
   `NSUInteger`, or `CGFloat` (which follow the first rule above),
   the *type name* is that of the underlying type. For example, when
   the Objective-C type is `UILayoutPriority`, which is a typedef for
-  `float`, we try to match the string "`Float`". [[Compensate for Weak Type Information](https://swift.org/documentation/api-design-guidelines#weak-type-information)]
+  `float`, we try to match the string "`Float`". [[Compensate for Weak Type Information](https://swift.org/documentation/api-design-guidelines.html#weak-type-information)]
 
 #### Matching
 

--- a/proposals/0005-objective-c-name-translation.md
+++ b/proposals/0005-objective-c-name-translation.md
@@ -1,6 +1,6 @@
 # Better Translation of Objective-C APIs Into Swift
 
-* Proposal: [SE-0005](https://github.com/apple/swift-evolution/proposals/0005-objective-c-name-translation.md)
+* Proposal: [SE-0005](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md)
 * Author(s): [Doug Gregor](https://github.com/DougGregor), [Dave Abrahams](https://github.com/dabrahams)
 * Status: **Accepted**
 

--- a/proposals/0005-objective-c-name-translation.md
+++ b/proposals/0005-objective-c-name-translation.md
@@ -294,7 +294,7 @@ func arrange<b>Objects</b>(_: <b>[</b>Any<b>Object]</b>) -> [AnyObject]
     <pre>
 func writableTypesFor<b>SaveOperation</b>(_: NS<b>SaveOperation</b><i>Type</i>) -> [String]
 func objectFor<b>Key</b>(_: <b>Key</b><i>Type</i>) -> AnyObject
-func startWith<b>Queue</b>(_: dispatch<b>queue</b><i>_t</i>, completionHandler: MKMapSnapshotCompletionhandler)
+func startWith<b>Queue</b>(_: dispatch_<b>queue</b><i>_t</i>, completionHandler: MKMapSnapshotCompletionhandler)
 </pre>
 
   * The empty string in the selector piece matches *one or more digits

--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -1,6 +1,6 @@
 # Apply API Guidelines to the Standard Library
 
-* Proposal: [SE-0006](https://github.com/apple/swift-evolution/proposals/0006-apply-api-guidelines-to-the-standard-library.md)
+* Proposal: [SE-0006](https://github.com/apple/swift-evolution/blob/master/proposals/0006-apply-api-guidelines-to-the-standard-library.md)
 * Author(s): [Dave Abrahams](https://github.com/dabrahams), [Dmitri Gribenko](https://github.com/gribozavr), [Maxim Moiseev](https://github.com/moiseev)
 * Status: **Awaiting Review**
 * Review manager: [Doug Gregor](https://github.com/DougGregor)

--- a/proposals/0006-apply-api-guidelines-to-the-standard-library.md
+++ b/proposals/0006-apply-api-guidelines-to-the-standard-library.md
@@ -37,7 +37,7 @@ On high level, the changes can be summarized as follows.
 
 Differences between Swift 2.2 Standard library API and the proposed API are
 added to this section as they are being implemented on the
-[swift-3-api-guidelines branch][swift-3-api-guidelines-repo].
+[swift-3-api-guidelines branch][swift-3-api-guidelines-branch].
 
 ## Impact on existing code
 

--- a/proposals/0007-remove-c-style-for-loops.md
+++ b/proposals/0007-remove-c-style-for-loops.md
@@ -1,9 +1,9 @@
 # Remove C-style for-loops with conditions and incrementers
 
-* Proposal: [SE-NNNN](https://github.com/apple/swift-evolution/blob/master/proposals/NNNN-name.md)
+* Proposal: [SE-0007](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 * Author(s): [Erica Sadun](https://github.com/erica)
-* Status: **Review**
-* Review manager: TBD
+* Status: **Awaiting review**
+* Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction
 

--- a/proposals/0007-remove-c-style-for-loops.md
+++ b/proposals/0007-remove-c-style-for-loops.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0007](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 * Author(s): [Erica Sadun](https://github.com/erica)
-* Status: **Awaiting review**
+* Status: **Awaiting review** (scheduled for December 7, 2015 -- December 10, 2015)
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/proposals/0007-remove-c-style-for-loops.md
+++ b/proposals/0007-remove-c-style-for-loops.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SE-0007](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 * Author(s): [Erica Sadun](https://github.com/erica)
-* Status: **Awaiting review** (scheduled for December 7, 2015 -- December 10, 2015)
+* Status: **Under review** (December 7, 2015 -- December 10, 2015)
 * Review manager: [Doug Gregor](https://github.com/DougGregor)
 
 ## Introduction

--- a/schedule.md
+++ b/schedule.md
@@ -6,11 +6,11 @@ proposals in that process.
 
 ## Active reviews
 
-(No active reviews)
+* December 7, 2015 -- December 10, 2015: [Remove C-style for-loops with conditions and incrementers](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 
 ## Upcoming reviews
 
-* December 7, 2015 -- December 10, 2015: [Remove C-style for-loops with conditions and incrementers](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
+(No proposals with upcoming reviews)
 
 ## Proposals awaiting scheduling
 

--- a/schedule.md
+++ b/schedule.md
@@ -14,7 +14,7 @@ proposals in that process.
 
 ## Proposals awaiting scheduling
 
-[Remove C-style for-loops with conditions and incrementers](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
+* [Remove C-style for-loops with conditions and incrementers](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 
 [evolution-process]: process.md  "The Swift evolution process"
 

--- a/schedule.md
+++ b/schedule.md
@@ -14,7 +14,7 @@ proposals in that process.
 
 ## Proposals awaiting scheduling
 
-https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md
+[Remove C-style for-loops with conditions and incrementers](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 
 [evolution-process]: process.md  "The Swift evolution process"
 

--- a/schedule.md
+++ b/schedule.md
@@ -14,7 +14,7 @@ proposals in that process.
 
 ## Proposals awaiting scheduling
 
-(No proposals awaiting scheduling)
+https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md
 
 [evolution-process]: process.md  "The Swift evolution process"
 

--- a/schedule.md
+++ b/schedule.md
@@ -10,11 +10,11 @@ proposals in that process.
 
 ## Upcoming reviews
 
-(No upcoming reviews)
+* December 7, 2015 -- December 10, 2015: [Remove C-style for-loops with conditions and incrementers](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
 
 ## Proposals awaiting scheduling
 
-* [Remove C-style for-loops with conditions and incrementers](https://github.com/apple/swift-evolution/blob/master/proposals/0007-remove-c-style-for-loops.md)
+(No proposals awaiting scheduling)
 
 [evolution-process]: process.md  "The Swift evolution process"
 


### PR DESCRIPTION
In swift we are able to add extension of classes that allows us to add methods but we cannot add attributes, properties.

C# language allows developers to make its classes partial. It is possible to split the definition of class, struct or interface over two or more source files.

Could we make swift able to do this stuff ?
